### PR TITLE
Modify setup.sh order

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,6 @@
 # Update and install system dependencies
 sudo apt update
-sudo apt install -y python3-pip python3-setuptools git zip unzip openjdk-11-jdk
+sudo apt install -y python3-pip python3-setuptools python3-venv git zip unzip openjdk-11-jdk
 
 # Optional but recommended: create and activate a virtual environment
 python3 -m venv buildozer-env


### PR DESCRIPTION
## Summary
- reorder system package installation before creating virtual environment in `setup.sh`
- include `python3-venv` in dependencies

## Testing
- `bash -n setup.sh`
