### PR TITLE
Update setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,16 +1,13 @@
 # AGENTS.md
-## Setup
-
-- Run the following script to install Buildozer, python-for-android, and Android SDK/NDK:
-
-chmod u+x setup.sh
-./setup.sh
-buildozer android debug
-
 
 ## Setup
-- Ensure Buildozer (and its dependencies such as python-for-android, Android SDK/NDK) are installed before the session’s network access is disabled.  
+- Ensure Buildozer (and its dependencies such as python-for-android, Android SDK/NDK) are installed before the session’s network access is disabled.
   *If these tools aren’t preinstalled or provided via a setup script, the build will fail.*
+- Run the following commands to install Buildozer and its dependencies:
+  ```sh
+  chmod u+x setup.sh
+  ./setup.sh
+  ```
 
 ## Build
 - Run `buildozer android debug` to generate an APK from `main.py` using `buildozer.spec`.


### PR DESCRIPTION
## Summary
- rearrange AGENTS.md to put setup prerequisites before running the setup script

## Testing
- `./setup.sh` *(fails: could not access network)*
- `buildozer android debug` *(fails: command not found)*